### PR TITLE
Fixed Aws\Constantly error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "A composer plugin that allows installing packages stored on S3",
     "keywords": ["amazon", "aws", "s3", "composer", "composer-plugin", "plugin"],
     "license": "MIT",
-    "version": "1.0.0",
     "authors": [
         {
             "name": "Nils Adermann",

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "description": "A composer plugin that allows installing packages stored on S3",
     "keywords": ["amazon", "aws", "s3", "composer", "composer-plugin", "plugin"],
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "Nils Adermann",

--- a/src/Naderman/Composer/AWS/AwsClient.php
+++ b/src/Naderman/Composer/AWS/AwsClient.php
@@ -206,7 +206,12 @@ class AwsClient
             }
 
             if (!function_exists('AWS\manifest')) {
-                require_once __DIR__ . '/../../../../../../aws/aws-sdk-php/src/functions.php';
+                // This file has to be loaded with the exact same name as in the composer static autoloader to avoid
+                // including it twice, which leads to functions in the AWS Namespace to be declared twice.
+                $static_include_path = __DIR__ . '/../../../../../../composer/autoload_static.php';
+                $static_include_path = realpath($static_include_path);
+                $static_include_path = dirname($static_include_path);
+                require_once   $static_include_path . '/../aws/aws-sdk-php/src/functions.php';
             }
             
             if (!function_exists('GuzzleHttp\Psr7\uri_for')) {

--- a/src/Naderman/Composer/AWS/AwsClient.php
+++ b/src/Naderman/Composer/AWS/AwsClient.php
@@ -205,13 +205,15 @@ class AwsClient
                 $s3config['profile'] = getenv('AWS_DEFAULT_PROFILE');
             }
 
-            if (!function_exists('AWS\manifest')) {
+            $static_include_path = __DIR__ . '/../../../../../../composer/autoload_static.php';
+            if ( file_exists( $static_include_path)){
                 // This file has to be loaded with the exact same name as in the composer static autoloader to avoid
                 // including it twice, which leads to functions in the AWS Namespace to be declared twice.
-                $static_include_path = __DIR__ . '/../../../../../../composer/autoload_static.php';
                 $static_include_path = realpath($static_include_path);
                 $static_include_path = dirname($static_include_path);
                 require_once   $static_include_path . '/../aws/aws-sdk-php/src/functions.php';
+            } else if (!function_exists('AWS\manifest')) {
+                require_once __DIR__ . '/../../../../../../aws/aws-sdk-php/src/functions.php';
             }
             
             if (!function_exists('GuzzleHttp\Psr7\uri_for')) {


### PR DESCRIPTION
Fixes issue https://github.com/naderman/composer-aws/issues/15 , AWS redeclaration error by ensuring the require_once path is the same.